### PR TITLE
Fix code typo in the Quick Start section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ new acl_knex.setup(function() {
 #Quick Start
 ```javascript
 	Acl = require('acl');
-	AclKnexBackend = require('acl_knex');
+	AclKnexBackend = require('acl-knex');
 	knex = require('knex');
 
 	var db = knex({


### PR DESCRIPTION
Hi, I was getting familiar with this and found a code typo in the Quick Start.  Works great with a "-" in place of the "_".  Cheers!