### PR TITLE
SQLite support

### DIFF
--- a/lib/databaseTasks.js
+++ b/lib/databaseTasks.js
@@ -4,20 +4,25 @@ var _ = require('lodash');
 var buckets = require('./buckets');
 var knex = require('knex');
 
-var downSql = 'DROP TABLE IF EXISTS "{{prefix}}{{meta}}";'+
-	'DROP TABLE IF EXISTS "{{prefix}}{{resources}}";'+
-	'DROP TABLE IF EXISTS "{{prefix}}{{parents}}";'+
-	'DROP TABLE IF EXISTS "{{prefix}}{{users}}";'+
-	'DROP TABLE IF EXISTS "{{prefix}}{{roles}}";'+
-	'DROP TABLE IF EXISTS "{{prefix}}{{permissions}}";';
-var upSql = 'CREATE TABLE "{{prefix}}{{meta}}" (key TEXT NOT NULL PRIMARY KEY, value TEXT[][] NOT NULL);'+
-	'INSERT INTO "{{prefix}}{{meta}}" VALUES (\'users\', \'{}\');'+
-	'INSERT INTO "{{prefix}}{{meta}}" VALUES (\'roles\', \'{}\');'+
-	'CREATE TABLE "{{prefix}}{{resources}}" (key TEXT NOT NULL PRIMARY KEY, value TEXT[][] NOT NULL);'+
-	'CREATE TABLE "{{prefix}}{{parents}}" (key TEXT NOT NULL PRIMARY KEY, value TEXT[][] NOT NULL);'+
-	'CREATE TABLE "{{prefix}}{{roles}}" (key TEXT NOT NULL PRIMARY KEY, value TEXT[][] NOT NULL);'+
-	'CREATE TABLE "{{prefix}}{{users}}" (key TEXT NOT NULL PRIMARY KEY, value TEXT[][] NOT NULL);'+
-	'CREATE TABLE "{{prefix}}{{permissions}}" (key TEXT NOT NULL PRIMARY KEY, value JSON NOT NULL);';
+var downSql = [
+	'DROP TABLE IF EXISTS "{{prefix}}{{meta}}";',
+	'DROP TABLE IF EXISTS "{{prefix}}{{resources}}";',
+	'DROP TABLE IF EXISTS "{{prefix}}{{parents}}";',
+	'DROP TABLE IF EXISTS "{{prefix}}{{users}}";',
+	'DROP TABLE IF EXISTS "{{prefix}}{{roles}}";',
+	'DROP TABLE IF EXISTS "{{prefix}}{{permissions}}";'
+];
+
+var upSql = [
+	'CREATE TABLE "{{prefix}}{{meta}}" (key TEXT NOT NULL PRIMARY KEY, value TEXT[][] NOT NULL);',
+	'INSERT INTO "{{prefix}}{{meta}}" VALUES (\'users\', \'{}\');',
+	'INSERT INTO "{{prefix}}{{meta}}" VALUES (\'roles\', \'{}\');',
+	'CREATE TABLE "{{prefix}}{{resources}}" (key TEXT NOT NULL PRIMARY KEY, value TEXT[][] NOT NULL);',
+	'CREATE TABLE "{{prefix}}{{parents}}" (key TEXT NOT NULL PRIMARY KEY, value TEXT[][] NOT NULL);',
+	'CREATE TABLE "{{prefix}}{{roles}}" (key TEXT NOT NULL PRIMARY KEY, value TEXT[][] NOT NULL);',
+	'CREATE TABLE "{{prefix}}{{users}}" (key TEXT NOT NULL PRIMARY KEY, value TEXT[][] NOT NULL);',
+	'CREATE TABLE "{{prefix}}{{permissions}}" (key TEXT NOT NULL PRIMARY KEY, value JSON NOT NULL);'
+];
 
 function tmpl(str, ctx) {
 	var n = 1;
@@ -61,7 +66,7 @@ function dropTables(args, callback) {
 	}
 	if (!prefix) prefix = 'acl_';
 	
-	db.raw(tmpl(downSql, {
+	executeStatements(db, downSql, {
             'meta': bucketNames.meta,
             'parents': bucketNames.parents,
             'permissions': bucketNames.permissions,
@@ -69,7 +74,7 @@ function dropTables(args, callback) {
             'resources': bucketNames.resources,
             'roles': bucketNames.roles,
             'users': bucketNames.users
-        }))
+        })
         .then(function() {
             if (!_.isUndefined(callback)) {
                 callback(null, db);
@@ -86,21 +91,35 @@ function createTables(args, callback) {
 	}
 	if (!prefix) prefix = 'acl_';
 	
-	db.raw(tmpl(downSql+upSql, {
-            'meta': bucketNames.meta,
-            'parents': bucketNames.parents,
-            'permissions': bucketNames.permissions,
-            'prefix': prefix,
-            'resources': bucketNames.resources,
-            'roles': bucketNames.roles,
-            'users': bucketNames.users
-        }))
-        .then(function() {
-            if (!_.isUndefined(callback)) {
-                callback(null, db);
-            }
-        })
-    ;
+	executeStatements(db, downSql.concat(upSql), {
+		'meta': bucketNames.meta,
+		'parents': bucketNames.parents,
+		'permissions': bucketNames.permissions,
+		'prefix': prefix,
+		'resources': bucketNames.resources,
+		'roles': bucketNames.roles,
+		'users': bucketNames.users
+	})
+	.then(function() {
+		if (!_.isUndefined(callback)) {
+			callback(null, db);
+		}
+	})
+	.catch(error => {
+		console.error(error);
+	});
+}
+
+function executeStatements(db, statements, bucketNames) {
+	return executeStatement(0)
+	
+	function executeStatement(statementNumber) {
+		if(statementNumber < statements.length) {
+		  	return db.raw(tmpl(statements[statementNumber], bucketNames)).then(() => {
+				return executeStatement(++statementNumber)	
+			})
+		}
+	}
 }
 
 exports.createTables = createTables;

--- a/lib/knex-backend.js
+++ b/lib/knex-backend.js
@@ -69,7 +69,8 @@ KnexDBBackend.prototype = {
 				.where({'key': bucket})
 				.then(function(result) {
 					if (result.length) {
-						cb(undefined, (result[0].value[key] ? result[0].value[key] : []));
+						var value = JSON.parse(result[0].value)
+						cb(undefined, (value[key] || []));
 					} else {
 						cb(undefined, []);
 					}
@@ -82,7 +83,7 @@ KnexDBBackend.prototype = {
 				.from(table)
 				.where({'key': key})
 				.then(function(result) {
-					cb(undefined, (result.length ? result[0].value : []));
+					cb(undefined, (result.length ? JSON.parse(result[0].value) : []));
 				})
 			;
 		}
@@ -108,7 +109,7 @@ KnexDBBackend.prototype = {
 					if (results.length && results[0].value) {
 						var keyArrays = [];
 						_.each(keys, function(key) {
-							keyArrays.push.apply(keyArrays, results[0].value[key]);
+							keyArrays.push.apply(keyArrays, JSON.parse(results[0].value)[key]);
 						});
 						cb(undefined, _.union(keyArrays));
 					} else {
@@ -127,7 +128,7 @@ KnexDBBackend.prototype = {
 					if (results.length) {
 						var keyArrays = [];
 						_.each(results, function(result) {
-							keyArrays.push.apply(keyArrays, result.value);
+							keyArrays.push.apply(keyArrays, JSON.parse(result.value));
 						});
 						cb(undefined, _.union(keyArrays));
 					} else {
@@ -167,20 +168,21 @@ KnexDBBackend.prototype = {
 							// if no results found do a fresh insert
 							json[key] = values;
 							return self.db(table)
-								.insert({key: bucket, value: json})
+								.insert({key: bucket, value: JSON.stringify(json)})
 							;
 						} else {
+							var value = JSON.parse(result[0].value)
 							
 							// if we have found the key in the table then lets refresh the data
-							if (_.has(result[0].value, key)) {
-								result[0].value[key] = _.union(values, result[0].value[key]);
+							if (_.has(value, key)) {
+								value[key] = _.union(values, value[key]);
 							} else {
-								result[0].value[key] = values;
+								value[key] = values;
 							}
 							
 							return self.db(table)
 								.where('key', bucket)
-								.update({key: bucket, value: result[0].value})
+								.update({key: bucket, value: JSON.stringify(value)})
 							;
 						}
 					})
@@ -200,14 +202,14 @@ KnexDBBackend.prototype = {
 							
 							// if no results found do a fresh insert
 							return self.db(table)
-								.insert({key: key, value: values})
+								.insert({key: key, value: JSON.stringify(values)})
 							;
 						} else {
 							
 							// if we have found the key in the table then lets refresh the data
 							return self.db(table)
 								.where('key', key)
-								.update({value: _.union(values, result[0].value)})
+								.update({value: JSON.stringify(_.union(values, JSON.parse(result[0].value)))})
 							;
 						}
 					})
@@ -245,8 +247,10 @@ KnexDBBackend.prototype = {
 						if (result.length === 0) {
 							
 						} else {
-							_.each(keys, function(value) {
-								result[0].value = _.omit(result[0].value, value);
+							var value = JSON.parse(result[0].value)
+
+							_.each(keys, function(keyValue) {
+								value = _.omit(value, keyValue);
 							});
 							
 							if (_.isEmpty(result[0].value)) {
@@ -258,7 +262,7 @@ KnexDBBackend.prototype = {
 							} else {
 								return self.db(table)
 									.where('key', bucket)
-									.update({value: result[0].value})
+									.update({value: JSON.stringify(value)})
 								;
 							}
 						}
@@ -304,19 +308,21 @@ KnexDBBackend.prototype = {
 					.then(function(result) {
 						if(result.length === 0) {return;}
 						
+						var value = JSON.parse(result[0].value)
+
 						// update the permissions for the role by removing what was requested
-						_.each(values, function(value) {
-							result[0].value[key] = _.without(result[0].value[key], value);
+						_.each(values, function(keyValue) {
+							value[key] = _.without(value[key], keyValue);
 						});
 						
 						//  if no more permissions in the role then remove the role
-						if (!result[0].value[key].length) {
-							result[0].value = _.omit(result[0].value, key);
+						if (!value[key].length) {
+							value = _.omit(value, key);
 						}
 						
 						return self.db(table)
 							.where('key', bucket)
-							.update({value: result[0].value})
+							.update({value: JSON.stringify(value)})
 						;
 					})
 					.then(function() {
@@ -332,14 +338,14 @@ KnexDBBackend.prototype = {
 					.then(function(result) {
 						if(result.length === 0) {return;}
 						
-						var resultValues = result[0].value;
+						var resultValues = JSON.parse(result[0].value);
 						// if we have found the key in the table then lets remove the values from it
 						_.each(values, function(value) {
 							resultValues = _.without(resultValues, value);
 						});
 						return self.db(table)
 							.where('key', key)
-							.update({value: resultValues})
+							.update({value: JSON.stringify(resultValues)})
 						;
 					})
 					.then(function() {

--- a/test/runner.js
+++ b/test/runner.js
@@ -13,179 +13,179 @@ function run() {
 	});
 }
 
-// describe('Postgres', function () {
-// 	describe('testing setup method', function () {
-// 		before(function () {
-// 			error = null;
-// 			options = {
-// 				meta: 'meta',
-// 				parents: 'parents',
-// 				permissions: 'permissions',
-// 				resources: 'resources',
-// 				roles: 'roles',
-// 				users: 'users'
-// 			};
-// 		});
+describe('Postgres', function () {
+	describe('testing setup method', function () {
+		before(function () {
+			error = null;
+			options = {
+				meta: 'meta',
+				parents: 'parents',
+				permissions: 'permissions',
+				resources: 'resources',
+				roles: 'roles',
+				users: 'users'
+			};
+		});
 
-// 		describe('with passing options parameter', function () {
-// 			before(function (done) {
-// 				var self = this;
-// 				var db = knex({
-// 					client: 'postgres',
-// 					connection: 'postgres://postgres@127.0.0.1:5432/travis_ci_test'
-// 				});
+		describe('with passing options parameter', function () {
+			before(function (done) {
+				var self = this;
+				var db = knex({
+					client: 'postgres',
+					connection: 'postgres://postgres@127.0.0.1:5432/travis_ci_test'
+				});
 
-// 				new KnexBackend().setup([null, null, null, null, null, null, null, db, options], function(err, db) {
-// 					error = err;
-// 					if (err) return done(err);
-// 					done();
-// 				});
-// 			});
+				new KnexBackend().setup([null, null, null, null, null, null, null, db, options], function(err, db) {
+					error = err;
+					if (err) return done(err);
+					done();
+				});
+			});
 
-// 			it('should create tables in database with given options', function () {
-// 				assert(!error);
-// 			});
+			it('should create tables in database with given options', function () {
+				assert(!error);
+			});
 
-// 			describe('and then using teardown method', function () {
-// 				before(function (done) {
-// 					var self = this;
-// 					var db = knex({
-// 						client: 'postgres',
-// 						connection: 'postgres://postgres@127.0.0.1:5432/travis_ci_test'
-// 					});
-// 					new KnexBackend().teardown([null, null, null, null, null, null, null, db, options], function(err, db) {
-// 						error = err;
-// 						if (err) return done(err);
-// 						done();
-// 					});
-// 				});
+			describe('and then using teardown method', function () {
+				before(function (done) {
+					var self = this;
+					var db = knex({
+						client: 'postgres',
+						connection: 'postgres://postgres@127.0.0.1:5432/travis_ci_test'
+					});
+					new KnexBackend().teardown([null, null, null, null, null, null, null, db, options], function(err, db) {
+						error = err;
+						if (err) return done(err);
+						done();
+					});
+				});
 
-// 				it('should drop tables in database', function () {
-// 					assert(!error);
-// 				});
-// 			});
-// 		});
+				it('should drop tables in database', function () {
+					assert(!error);
+				});
+			});
+		});
 
-// 		describe('with passing db', function () {
-// 			before(function (done) {
-// 				var self = this;
-// 				var db = knex({
-// 					client: 'postgres',
-// 					connection: 'postgres://postgres@127.0.0.1:5432/travis_ci_test'
-// 				});
-// 				new KnexBackend().setup([null, null, null, null, null, null, null, db], function(err, db) {
-// 					error = err;
-// 					if (err) return done(err);
-// 					done();
-// 				});
-// 			});
+		describe('with passing db', function () {
+			before(function (done) {
+				var self = this;
+				var db = knex({
+					client: 'postgres',
+					connection: 'postgres://postgres@127.0.0.1:5432/travis_ci_test'
+				});
+				new KnexBackend().setup([null, null, null, null, null, null, null, db], function(err, db) {
+					error = err;
+					if (err) return done(err);
+					done();
+				});
+			});
 
-// 			it('should create tables in database', function () {
-// 				assert(!error);
-// 			});
+			it('should create tables in database', function () {
+				assert(!error);
+			});
 
-// 			describe('and then using teardown method', function () {
-// 				before(function (done) {
-// 					var self = this;
-// 					var db = knex({
-// 						client: 'postgres',
-// 						connection: 'postgres://postgres@127.0.0.1:5432/travis_ci_test'
-// 					});
-// 					new KnexBackend().teardown([null, null, null, null, null, null, null, db], function(err, db) {
-// 						error = err;
-// 						if (err) return done(err);
-// 						done();
-// 					});
-// 				});
+			describe('and then using teardown method', function () {
+				before(function (done) {
+					var self = this;
+					var db = knex({
+						client: 'postgres',
+						connection: 'postgres://postgres@127.0.0.1:5432/travis_ci_test'
+					});
+					new KnexBackend().teardown([null, null, null, null, null, null, null, db], function(err, db) {
+						error = err;
+						if (err) return done(err);
+						done();
+					});
+				});
 
-// 				it('should drop tables in database', function () {
-// 					assert(!error);
-// 				});
-// 			});
-// 		});
+				it('should drop tables in database', function () {
+					assert(!error);
+				});
+			});
+		});
 
-// 		describe('with connection string', function () {
-// 			before(function (done) {
-// 				var self = this;
+		describe('with connection string', function () {
+			before(function (done) {
+				var self = this;
 
-// 				new KnexBackend().setup([null, null, null, null, null, null, 'postgres://postgres@127.0.0.1:5432/travis_ci_test'], function(err, db) {
-// 					error = err;
-// 					if (err) return done(err);
-// 					done();
-// 				});
-// 			});
+				new KnexBackend().setup([null, null, null, null, null, null, 'postgres://postgres@127.0.0.1:5432/travis_ci_test'], function(err, db) {
+					error = err;
+					if (err) return done(err);
+					done();
+				});
+			});
 
-// 			it('should create tables in database', function () {
-// 				assert(!error);
-// 			});
+			it('should create tables in database', function () {
+				assert(!error);
+			});
 
-// 			describe('and then using teardown method', function () {
-// 				before(function (done) {
-// 					var self = this;
+			describe('and then using teardown method', function () {
+				before(function (done) {
+					var self = this;
 
-// 					new KnexBackend().teardown([null, null, null, null, null, null, 'postgres://postgres@127.0.0.1:5432/travis_ci_test'], function(err, db) {
-// 						error = err;
-// 						if (err) return done(err);
-// 						done();
-// 					});
-// 				});
+					new KnexBackend().teardown([null, null, null, null, null, null, 'postgres://postgres@127.0.0.1:5432/travis_ci_test'], function(err, db) {
+						error = err;
+						if (err) return done(err);
+						done();
+					});
+				});
 
-// 				it('should drop tables in database', function () {
-// 					assert(!error);
-// 				});
-// 			});
-// 		});
+				it('should drop tables in database', function () {
+					assert(!error);
+				});
+			});
+		});
 
-// 		describe('without connection string', function () {
-// 			before(function (done) {
-// 				var self = this;
+		describe('without connection string', function () {
+			before(function (done) {
+				var self = this;
 
-// 				new KnexBackend().setup(['travis_ci_test', 'postgres'], function(err, db) {
-// 					error = err;
-// 					if (err) return done(err);
-// 					done();
-// 				});
-// 			});
+				new KnexBackend().setup(['travis_ci_test', 'postgres'], function(err, db) {
+					error = err;
+					if (err) return done(err);
+					done();
+				});
+			});
 
-// 			it('should create tables in database', function () {
-// 				assert(!error);
-// 			});
+			it('should create tables in database', function () {
+				assert(!error);
+			});
 
-// 			describe('and then using teardown method', function () {
-// 				before(function (done) {
-// 					var self = this;
+			describe('and then using teardown method', function () {
+				before(function (done) {
+					var self = this;
 
-// 					new KnexBackend().teardown(['travis_ci_test', 'postgres'], function(err, db) {
-// 						error = err;
-// 						if (err) return done(err);
-// 						done();
-// 					});
-// 				});
+					new KnexBackend().teardown(['travis_ci_test', 'postgres'], function(err, db) {
+						error = err;
+						if (err) return done(err);
+						done();
+					});
+				});
 
-// 				it('should drop tables in database', function () {
-// 					assert(!error);
-// 				});
-// 			});
-// 		});
-// 	});
+				it('should drop tables in database', function () {
+					assert(!error);
+				});
+			});
+		});
+	});
 
-// 	describe('Acl Test', function () {
-// 		before(function (done) {
-// 			var self = this;
-// 			var db = knex({
-// 				client: 'postgres',
-// 				connection: 'postgres://postgres@127.0.0.1:5432/travis_ci_test'
-// 			});
-// 			new KnexBackend().setup([null, null, null, null, null, null, null, db], function(err, db) {
-// 				if (err) return done(err);
-// 				self.backend = new KnexBackend(db, 'postgres', 'acl_');
-// 				done();
-// 			});
-// 		});
+	describe('Acl Test', function () {
+		before(function (done) {
+			var self = this;
+			var db = knex({
+				client: 'postgres',
+				connection: 'postgres://postgres@127.0.0.1:5432/travis_ci_test'
+			});
+			new KnexBackend().setup([null, null, null, null, null, null, null, db], function(err, db) {
+				if (err) return done(err);
+				self.backend = new KnexBackend(db, 'postgres', 'acl_');
+				done();
+			});
+		});
 
-// 		run();
-// 	});
-// });
+		run();
+	});
+});
 
 // Mysql and SQLite support coming soon.
 

--- a/test/runner.js
+++ b/test/runner.js
@@ -13,179 +13,179 @@ function run() {
 	});
 }
 
-describe('Postgres', function () {
-	describe('testing setup method', function () {
-		before(function () {
-			error = null;
-			options = {
-				meta: 'meta',
-				parents: 'parents',
-				permissions: 'permissions',
-				resources: 'resources',
-				roles: 'roles',
-				users: 'users'
-			};
-		});
+// describe('Postgres', function () {
+// 	describe('testing setup method', function () {
+// 		before(function () {
+// 			error = null;
+// 			options = {
+// 				meta: 'meta',
+// 				parents: 'parents',
+// 				permissions: 'permissions',
+// 				resources: 'resources',
+// 				roles: 'roles',
+// 				users: 'users'
+// 			};
+// 		});
 
-		describe('with passing options parameter', function () {
-			before(function (done) {
-				var self = this;
-				var db = knex({
-					client: 'postgres',
-					connection: 'postgres://postgres@127.0.0.1:5432/travis_ci_test'
-				});
+// 		describe('with passing options parameter', function () {
+// 			before(function (done) {
+// 				var self = this;
+// 				var db = knex({
+// 					client: 'postgres',
+// 					connection: 'postgres://postgres@127.0.0.1:5432/travis_ci_test'
+// 				});
 
-				new KnexBackend().setup([null, null, null, null, null, null, null, db, options], function(err, db) {
-					error = err;
-					if (err) return done(err);
-					done();
-				});
-			});
+// 				new KnexBackend().setup([null, null, null, null, null, null, null, db, options], function(err, db) {
+// 					error = err;
+// 					if (err) return done(err);
+// 					done();
+// 				});
+// 			});
 
-			it('should create tables in database with given options', function () {
-				assert(!error);
-			});
+// 			it('should create tables in database with given options', function () {
+// 				assert(!error);
+// 			});
 
-			describe('and then using teardown method', function () {
-				before(function (done) {
-					var self = this;
-					var db = knex({
-						client: 'postgres',
-						connection: 'postgres://postgres@127.0.0.1:5432/travis_ci_test'
-					});
-					new KnexBackend().teardown([null, null, null, null, null, null, null, db, options], function(err, db) {
-						error = err;
-						if (err) return done(err);
-						done();
-					});
-				});
+// 			describe('and then using teardown method', function () {
+// 				before(function (done) {
+// 					var self = this;
+// 					var db = knex({
+// 						client: 'postgres',
+// 						connection: 'postgres://postgres@127.0.0.1:5432/travis_ci_test'
+// 					});
+// 					new KnexBackend().teardown([null, null, null, null, null, null, null, db, options], function(err, db) {
+// 						error = err;
+// 						if (err) return done(err);
+// 						done();
+// 					});
+// 				});
 
-				it('should drop tables in database', function () {
-					assert(!error);
-				});
-			});
-		});
+// 				it('should drop tables in database', function () {
+// 					assert(!error);
+// 				});
+// 			});
+// 		});
 
-		describe('with passing db', function () {
-			before(function (done) {
-				var self = this;
-				var db = knex({
-					client: 'postgres',
-					connection: 'postgres://postgres@127.0.0.1:5432/travis_ci_test'
-				});
-				new KnexBackend().setup([null, null, null, null, null, null, null, db], function(err, db) {
-					error = err;
-					if (err) return done(err);
-					done();
-				});
-			});
+// 		describe('with passing db', function () {
+// 			before(function (done) {
+// 				var self = this;
+// 				var db = knex({
+// 					client: 'postgres',
+// 					connection: 'postgres://postgres@127.0.0.1:5432/travis_ci_test'
+// 				});
+// 				new KnexBackend().setup([null, null, null, null, null, null, null, db], function(err, db) {
+// 					error = err;
+// 					if (err) return done(err);
+// 					done();
+// 				});
+// 			});
 
-			it('should create tables in database', function () {
-				assert(!error);
-			});
+// 			it('should create tables in database', function () {
+// 				assert(!error);
+// 			});
 
-			describe('and then using teardown method', function () {
-				before(function (done) {
-					var self = this;
-					var db = knex({
-						client: 'postgres',
-						connection: 'postgres://postgres@127.0.0.1:5432/travis_ci_test'
-					});
-					new KnexBackend().teardown([null, null, null, null, null, null, null, db], function(err, db) {
-						error = err;
-						if (err) return done(err);
-						done();
-					});
-				});
+// 			describe('and then using teardown method', function () {
+// 				before(function (done) {
+// 					var self = this;
+// 					var db = knex({
+// 						client: 'postgres',
+// 						connection: 'postgres://postgres@127.0.0.1:5432/travis_ci_test'
+// 					});
+// 					new KnexBackend().teardown([null, null, null, null, null, null, null, db], function(err, db) {
+// 						error = err;
+// 						if (err) return done(err);
+// 						done();
+// 					});
+// 				});
 
-				it('should drop tables in database', function () {
-					assert(!error);
-				});
-			});
-		});
+// 				it('should drop tables in database', function () {
+// 					assert(!error);
+// 				});
+// 			});
+// 		});
 
-		describe('with connection string', function () {
-			before(function (done) {
-				var self = this;
+// 		describe('with connection string', function () {
+// 			before(function (done) {
+// 				var self = this;
 
-				new KnexBackend().setup([null, null, null, null, null, null, 'postgres://postgres@127.0.0.1:5432/travis_ci_test'], function(err, db) {
-					error = err;
-					if (err) return done(err);
-					done();
-				});
-			});
+// 				new KnexBackend().setup([null, null, null, null, null, null, 'postgres://postgres@127.0.0.1:5432/travis_ci_test'], function(err, db) {
+// 					error = err;
+// 					if (err) return done(err);
+// 					done();
+// 				});
+// 			});
 
-			it('should create tables in database', function () {
-				assert(!error);
-			});
+// 			it('should create tables in database', function () {
+// 				assert(!error);
+// 			});
 
-			describe('and then using teardown method', function () {
-				before(function (done) {
-					var self = this;
+// 			describe('and then using teardown method', function () {
+// 				before(function (done) {
+// 					var self = this;
 
-					new KnexBackend().teardown([null, null, null, null, null, null, 'postgres://postgres@127.0.0.1:5432/travis_ci_test'], function(err, db) {
-						error = err;
-						if (err) return done(err);
-						done();
-					});
-				});
+// 					new KnexBackend().teardown([null, null, null, null, null, null, 'postgres://postgres@127.0.0.1:5432/travis_ci_test'], function(err, db) {
+// 						error = err;
+// 						if (err) return done(err);
+// 						done();
+// 					});
+// 				});
 
-				it('should drop tables in database', function () {
-					assert(!error);
-				});
-			});
-		});
+// 				it('should drop tables in database', function () {
+// 					assert(!error);
+// 				});
+// 			});
+// 		});
 
-		describe('without connection string', function () {
-			before(function (done) {
-				var self = this;
+// 		describe('without connection string', function () {
+// 			before(function (done) {
+// 				var self = this;
 
-				new KnexBackend().setup(['travis_ci_test', 'postgres'], function(err, db) {
-					error = err;
-					if (err) return done(err);
-					done();
-				});
-			});
+// 				new KnexBackend().setup(['travis_ci_test', 'postgres'], function(err, db) {
+// 					error = err;
+// 					if (err) return done(err);
+// 					done();
+// 				});
+// 			});
 
-			it('should create tables in database', function () {
-				assert(!error);
-			});
+// 			it('should create tables in database', function () {
+// 				assert(!error);
+// 			});
 
-			describe('and then using teardown method', function () {
-				before(function (done) {
-					var self = this;
+// 			describe('and then using teardown method', function () {
+// 				before(function (done) {
+// 					var self = this;
 
-					new KnexBackend().teardown(['travis_ci_test', 'postgres'], function(err, db) {
-						error = err;
-						if (err) return done(err);
-						done();
-					});
-				});
+// 					new KnexBackend().teardown(['travis_ci_test', 'postgres'], function(err, db) {
+// 						error = err;
+// 						if (err) return done(err);
+// 						done();
+// 					});
+// 				});
 
-				it('should drop tables in database', function () {
-					assert(!error);
-				});
-			});
-		});
-	});
+// 				it('should drop tables in database', function () {
+// 					assert(!error);
+// 				});
+// 			});
+// 		});
+// 	});
 
-	describe('Acl Test', function () {
-		before(function (done) {
-			var self = this;
-			var db = knex({
-				client: 'postgres',
-				connection: 'postgres://postgres@127.0.0.1:5432/travis_ci_test'
-			});
-			new KnexBackend().setup([null, null, null, null, null, null, null, db], function(err, db) {
-				if (err) return done(err);
-				self.backend = new KnexBackend(db, 'postgres', 'acl_');
-				done();
-			});
-		});
+// 	describe('Acl Test', function () {
+// 		before(function (done) {
+// 			var self = this;
+// 			var db = knex({
+// 				client: 'postgres',
+// 				connection: 'postgres://postgres@127.0.0.1:5432/travis_ci_test'
+// 			});
+// 			new KnexBackend().setup([null, null, null, null, null, null, null, db], function(err, db) {
+// 				if (err) return done(err);
+// 				self.backend = new KnexBackend(db, 'postgres', 'acl_');
+// 				done();
+// 			});
+// 		});
 
-		run();
-	});
-});
+// 		run();
+// 	});
+// });
 
 // Mysql and SQLite support coming soon.
 
@@ -217,17 +217,22 @@ describe('Postgres', function () {
 // 	run();
 // });
 
-// describe('SQLite', function () {
-// 	before(function (done) {
-// 		var self = this;
-// 		var db = knex({
-// 			client: 'sqlite',
-// 			connection: {
-// 				filename: './travis_ci_test.sqlite'
-// 			}
-// 		});
+describe('SQLite', function () {
+	before(function (done) {
+		var self = this;
+		var db = knex({
+			client: 'sqlite3',
+			connection: {
+				filename: './test.sqlite'
+			}
+		});
 
-// 	});
+		new KnexBackend().setup([null, null, null, null, null, null, null, db], function(err, db) {
+			if (err) return done(err);
+			self.backend = new KnexBackend(db, 'sqlite3', 'acl_');
+			done();
+		});
+	});
 
-// 	run();
-// });
+	run();
+});

--- a/test/runner.js
+++ b/test/runner.js
@@ -223,7 +223,7 @@ describe('SQLite', function () {
 		var db = knex({
 			client: 'sqlite3',
 			connection: {
-				filename: './test.sqlite'
+				filename: './travis_ci_test.sqlite'
 			}
 		});
 


### PR DESCRIPTION
This is a relatively straightforward change. Basically it explicitly calls JSON.stringify on the value column before inserting / updating and parses it on the way out. Additionally, the set of SQL statements used for setup / teardown are executed individually (SQLite does not support multiple statements in the same command). 

I've run the tests against SQLite and all pass, but have not run them against MySQL or PostgreSQL. I see no reason why they should fail, at least on PostgreSQL.

Let me know what you think. This should resolve #18 and #19.